### PR TITLE
Separated write() and flush() operations on channel for bulk operations.

### DIFF
--- a/server/tcp-server/src/main/java/cc/blynk/server/model/auth/Session.java
+++ b/server/tcp-server/src/main/java/cc/blynk/server/model/auth/Session.java
@@ -51,6 +51,20 @@ public class Session {
         channelSet.add(channel);
     }
 
+    public void pendMessageToHardware(MessageBase message) {
+        for (Channel channel : hardwareChannels) {
+            log.trace("Pending {} to {}", message, channel);
+            channel.write(message);
+        }
+    }
+
+    public void flushPendingMessagesToHardware() {
+        for (Channel channel : hardwareChannels) {
+            log.trace("Flush on {}", channel);
+            channel.flush();
+        }
+    }
+
     public void sendMessageToHardware(MessageBase message) {
         for (Channel channel : hardwareChannels) {
             log.trace("Sending {} to {}", message, channel);

--- a/server/tcp-server/src/main/java/cc/blynk/server/workers/timer/TimerWorker.java
+++ b/server/tcp-server/src/main/java/cc/blynk/server/workers/timer/TimerWorker.java
@@ -58,6 +58,8 @@ public class TimerWorker implements Runnable {
             }
         }
 
+        sessionsHolder.getUserSession().values().forEach(Session::flushPendingMessagesToHardware);
+
         //logging only events when timers ticked.
         if (onlineTimers > 0) {
             log.info("Timer finished. Processed {}/{}/{} timers.", onlineTimers, tickedTimers, allTimers);
@@ -71,7 +73,7 @@ public class TimerWorker implements Runnable {
             if (session != null) {
                 onlineTimers++;
                 if (session.hardwareChannels.size() > 0) {
-                    session.sendMessageToHardware(new HardwareMessage(7777, value));
+                    session.pendMessageToHardware(new HardwareMessage(7777, value));
                 }
             }
         }


### PR DESCRIPTION
Should definitely speedup the execution due to the big cost of Channel.flush() operation.