### PR TITLE
Batch msg writes in both directions (app<->hrdwr)

### DIFF
--- a/integration-tests/src/test/resources/server.properties
+++ b/integration-tests/src/test/resources/server.properties
@@ -80,3 +80,7 @@ administration.https.port=7443
 #you may set it for 0.0.0.0/0 to allow access for all.
 #you may use CIDR notation. For instance, 192.168.0.53/24
 allowed.administrator.ips=127.0.0.1
+
+#Batch writing setting. Activates/deactivates logic behind Gathering{Read|Write}Handlers.
+#Set on 'true' by default, turn it off if unsure.
+enable.channel.batchWrites=true

--- a/server/core/src/main/java/cc/blynk/server/core/batch/FlushWritesTaskHolder.java
+++ b/server/core/src/main/java/cc/blynk/server/core/batch/FlushWritesTaskHolder.java
@@ -1,0 +1,81 @@
+package cc.blynk.server.core.batch;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * {@link EventLoop} scoped holder for {@link FlushWritesTask}.
+ * <br/>
+ * This is thread-local facility to keep track writes produced by reads. Logic behind this class is bound to a fact
+ * that after every {@code epollEventLoop.processReady()} (or {@code nioEventLoop.processSelectedKeys()}) always goes a call
+ * to {@link SingleThreadEventExecutor#runAllTasks()} (or {@link SingleThreadEventExecutor#runAllTasks(long)}), that's why
+ * writes caught between first channel read and subsequent call to {@code runAllTasks}
+ * can be batched (<b>iff</b> writes occur within <b>same</b> EventLoop).
+ * <p>
+ * The Blynk Project.
+ * Created by Artem Vysochyn.
+ * Created on 20.04.16.
+ */
+public final class FlushWritesTaskHolder extends FastThreadLocal<FlushWritesTaskHolder.FlushWritesTask> {
+    private static final Logger log = LogManager.getLogger(FlushWritesTaskHolder.class);
+
+    static final Object FLUSH_EVENT = new Object();
+
+    @Override
+    protected FlushWritesTask initialValue() {
+        return FlushWritesTask.INSTANCE;
+    }
+
+    void setOnChannelRead(EventLoop eventLoop) {
+        SingleThreadEventExecutor eventLoop1 = (SingleThreadEventExecutor) eventLoop;
+        if (get() == FlushWritesTask.INSTANCE) {
+            FlushWritesTask task = new FlushWritesTask();
+            set(task);
+            //noinspection unchecked
+            eventLoop1.submit(task).addListener((GenericFutureListener) future -> remove());
+        }
+    }
+
+    boolean addDirtyChannel(Channel channel) {
+        boolean taskWasSet = get() != FlushWritesTask.INSTANCE;
+        if (taskWasSet) {
+            AtomicInteger ai = get().dirtyChannels.get(channel);
+            if (ai == null) {
+                get().dirtyChannels.put(channel, new AtomicInteger(1));
+            } else {
+                ai.incrementAndGet();
+            }
+        }
+        return taskWasSet;
+    }
+
+    public static class FlushWritesTask implements Runnable {
+        private static final FlushWritesTask INSTANCE = new FlushWritesTask();
+
+        private final Map<Channel, AtomicInteger> dirtyChannels = new HashMap<>();
+
+        @Override
+        public void run() {
+            for (Map.Entry<Channel, AtomicInteger> entry : dirtyChannels.entrySet()) {
+                log.debug("FlushWritesTask on channel: {}, writes: {}", entry.getKey(), entry.getValue());
+                try {
+                    entry.getKey().pipeline().fireUserEventTriggered(FLUSH_EVENT);
+                } catch (Throwable e) {
+                    log.warn("FlushWritesTask caught exception: {} on channel: ", e.getMessage(), entry.getKey());
+                }
+            }
+        }
+    }
+}

--- a/server/core/src/main/java/cc/blynk/server/core/batch/GatheringReadsHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/core/batch/GatheringReadsHandler.java
@@ -1,0 +1,35 @@
+package cc.blynk.server.core.batch;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * The Blynk Project.
+ * Created by Artem Vysochyn.
+ * Created on 20.04.16.
+ */
+@ChannelHandler.Sharable
+public final class GatheringReadsHandler extends ChannelInboundHandlerAdapter {
+    private final FlushWritesTaskHolder flushWritesTaskHolder;
+    private final boolean isEnabled;
+
+    public GatheringReadsHandler(FlushWritesTaskHolder flushWritesTaskHolder, boolean isEnabled) {
+        this.flushWritesTaskHolder = flushWritesTaskHolder;
+        this.isEnabled = isEnabled;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        flushWritesTaskHolder.setOnChannelRead(ctx.channel().eventLoop());
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        super.handlerAdded(ctx);
+        if (!isEnabled) {
+            ctx.pipeline().remove(this);
+        }
+    }
+}

--- a/server/core/src/main/java/cc/blynk/server/core/batch/GatheringWritesHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/core/batch/GatheringWritesHandler.java
@@ -1,0 +1,53 @@
+package cc.blynk.server.core.batch;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * The Blynk Project.
+ * Created by Artem Vysochyn.
+ * Created on 20.04.16.
+ */
+@ChannelHandler.Sharable
+public final class GatheringWritesHandler extends ChannelDuplexHandler {
+    private final FlushWritesTaskHolder flushWritesTaskHolder;
+    private final boolean isEnabled;
+
+    public GatheringWritesHandler(FlushWritesTaskHolder flushWritesTaskHolder, boolean isEnabled) {
+        this.flushWritesTaskHolder = flushWritesTaskHolder;
+        this.isEnabled = isEnabled;
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
+        if (flushWritesTaskHolder.addDirtyChannel(ctx.channel())) {
+            ctx.write(msg, promise);
+        } else {
+            ctx.writeAndFlush(msg, promise);
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt == FlushWritesTaskHolder.FLUSH_EVENT) {
+            ctx.flush();
+            return;
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) {
+        // no-op; used custom mechanism in write()
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        super.handlerAdded(ctx);
+        if (!isEnabled) {
+            ctx.pipeline().remove(this);
+        }
+    }
+}

--- a/server/core/src/main/resources/server.properties
+++ b/server/core/src/main/resources/server.properties
@@ -125,3 +125,7 @@ allowed.administrator.ips=127.0.0.1
 
 #comma separated list of users allowed to create accounts. leave it empty if no restriction required.
 allowed.users.list=
+
+#Batch writing setting. Activates/deactivates logic behind Gathering{Read|Write}Handlers.
+#Set on 'true' by default, turn it off if unsure.
+enable.channel.batchWrites=true

--- a/server/http-api/src/main/java/cc/blynk/server/api/http/HttpAPIServer.java
+++ b/server/http-api/src/main/java/cc/blynk/server/api/http/HttpAPIServer.java
@@ -30,6 +30,8 @@ public class HttpAPIServer extends BaseServer {
                 ch.pipeline().addLast(
                         new HttpServerCodec(),
                         new HttpObjectAggregator(1024, true),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         new HttpHandler(holder.userDao, holder.sessionDao, holder.stats)
                 );
             }

--- a/server/http-api/src/main/java/cc/blynk/server/api/http/HttpsAPIServer.java
+++ b/server/http-api/src/main/java/cc/blynk/server/api/http/HttpsAPIServer.java
@@ -37,6 +37,8 @@ public class HttpsAPIServer extends BaseServer {
                         new SniHandler(mappings),
                         new HttpServerCodec(),
                         new HttpObjectAggregator(1024, true),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         new HttpHandler(holder.userDao, holder.sessionDao, holder.stats)
                 );
             }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/AppServer.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/AppServer.java
@@ -57,6 +57,8 @@ public class AppServer extends BaseServer {
                         appChannelStateHandler,
                         new MessageDecoder(holder.stats),
                         new MessageEncoder(holder.stats),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         registerHandler,
                         appLoginHandler,
                         appShareLoginHandler,

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/HardwareServer.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/HardwareServer.java
@@ -41,6 +41,8 @@ public class HardwareServer extends BaseServer {
                 pipeline.addLast(hardwareChannelStateHandler,
                         new MessageDecoder(holder.stats),
                         new MessageEncoder(holder.stats),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         hardwareLoginHandler,
                         userNotLoggedHandler
                 );

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/ssl/HardwareSSLServer.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/ssl/HardwareSSLServer.java
@@ -49,6 +49,8 @@ public class HardwareSSLServer extends BaseServer {
                         hardwareChannelStateHandler,
                         new MessageDecoder(holder.stats),
                         new MessageEncoder(holder.stats),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         hardwareLoginHandler,
                         userNotLoggedHandler
                 );

--- a/server/web-socket/src/main/java/cc/blynk/server/websocket/WebSocketSSLServer.java
+++ b/server/web-socket/src/main/java/cc/blynk/server/websocket/WebSocketSSLServer.java
@@ -57,6 +57,8 @@ public class WebSocketSSLServer extends BaseServer {
                         new MessageDecoder(holder.stats),
                         new WebSocketWrapperEncoder(),
                         new WebSocketEncoder(holder.stats),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         hardwareLoginHandler,
                         userNotLoggedHandler
                 );

--- a/server/web-socket/src/main/java/cc/blynk/server/websocket/WebSocketServer.java
+++ b/server/web-socket/src/main/java/cc/blynk/server/websocket/WebSocketServer.java
@@ -51,6 +51,8 @@ public class WebSocketServer extends BaseServer {
                         new MessageDecoder(holder.stats),
                         new WebSocketWrapperEncoder(),
                         new WebSocketEncoder(holder.stats),
+                        holder.gatheringReadsHandler,
+                        holder.gatheringWritesHandler,
                         hardwareLoginHandler,
                         userNotLoggedHandler
                 );


### PR DESCRIPTION
Motivation:
Don't flush channel on every single msg write, rely on proxy-like architecture to decide when to flush. Improvement should lead to less load_avg and better latency. 

What was done:
After first ``read`` on any channel set a thread-local collection to catch upcoming _writing/dirty_ channels, and schedule a task in eventLoop to flush those caught _dirty_ channels.

**This solution was possible because of cool thing that ``Session``'s ``appChannels`` and ``hardwareChannels``, belonging to same ``token``, are beign assigned to the same ``eventLoop``, there by allowing to conduct read/write operations on channels in a same thread. 

 