### PR TITLE
Optimizartion in ByteBufUtil and in Session sendMessageTo*

### DIFF
--- a/server/core/src/main/java/cc/blynk/server/core/model/auth/Session.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/auth/Session.java
@@ -96,7 +96,7 @@ public class Session {
                 if (hardwareState.dashId == activeDashId) {
                     noActiveHardware = false;
                     log.trace("Sending {} to hardware {}", body, channel);
-                    channel.writeAndFlush(makeStringMessage(channel, cmd, msgId, body), channel.voidPromise());
+                    channel.writeAndFlush(makeStringMessage(cmd, msgId, body), channel.voidPromise());
                 }
             }
         }
@@ -107,7 +107,7 @@ public class Session {
     public void sendMessageToHardware(ChannelHandlerContext ctx, int activeDashId, short cmd, int msgId, String body) {
         if (sendMessageToHardware(activeDashId, cmd, msgId, body)) {
             log.debug("No device in session.");
-            ctx.writeAndFlush(makeResponse(ctx, msgId, Response.DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(msgId, Response.DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
         }
     }
 
@@ -126,14 +126,14 @@ public class Session {
     public void sendToApps(short cmd, int msgId, String body) {
         for (Channel channel : appChannels) {
             log.trace("Sending {} to app {}", body, channel);
-            channel.writeAndFlush(makeStringMessage(channel, cmd, msgId, body), channel.voidPromise());
+            channel.writeAndFlush(makeStringMessage(cmd, msgId, body), channel.voidPromise());
         }
     }
 
     public void sendToSharedApps(Channel sendingChannel, String sharedToken, short cmd, int msgId, String body) {
         for (Channel appChannel : appChannels) {
             if (appChannel != sendingChannel && needSync(appChannel, sharedToken)) {
-                appChannel.writeAndFlush(makeStringMessage(appChannel, cmd, msgId, body), appChannel.voidPromise());
+                appChannel.writeAndFlush(makeStringMessage(cmd, msgId, body), appChannel.voidPromise());
             }
         }
     }

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Button.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Button.java
@@ -23,7 +23,7 @@ public class Button extends OnePinWidget implements HardwareSyncWidget {
     public void send(ChannelHandlerContext ctx, int msgId) {
         String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Menu.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Menu.java
@@ -21,7 +21,7 @@ public class Menu extends OnePinWidget implements HardwareSyncWidget {
     public void send(ChannelHandlerContext ctx, int msgId) {
         String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/OneAxisJoystick.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/OneAxisJoystick.java
@@ -21,7 +21,7 @@ public class OneAxisJoystick extends OnePinWidget implements HardwareSyncWidget 
     public void send(ChannelHandlerContext ctx, int msgId) {
         String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/RGB.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/RGB.java
@@ -26,12 +26,12 @@ public class RGB extends MultiPinWidget implements HardwareSyncWidget {
         if (splitMode) {
             for (Pin pin : pins) {
                 if (pin.notEmpty()) {
-                    ctx.write(makeStringMessage(ctx, HARDWARE, msgId, pin.makeHardwareBody()), ctx.voidPromise());
+                    ctx.write(makeStringMessage(HARDWARE, msgId, pin.makeHardwareBody()), ctx.voidPromise());
                 }
             }
         } else {
             if (pins[0].notEmpty()) {
-                ctx.write(makeStringMessage(ctx, HARDWARE, msgId, makeHardwareBody()), ctx.voidPromise());
+                ctx.write(makeStringMessage(HARDWARE, msgId, makeHardwareBody()), ctx.voidPromise());
             }
         }
     }

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Slider.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Slider.java
@@ -19,7 +19,7 @@ public class Slider extends OnePinWidget implements HardwareSyncWidget {
     public void send(ChannelHandlerContext ctx, int msgId) {
         String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Step.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/Step.java
@@ -19,7 +19,7 @@ public class Step extends OnePinWidget implements HardwareSyncWidget {
     public void send(ChannelHandlerContext ctx, int msgId) {
         String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/TwoAxisJoystick.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/controls/TwoAxisJoystick.java
@@ -28,12 +28,12 @@ public class TwoAxisJoystick extends MultiPinWidget implements HardwareSyncWidge
         if (split) {
             for (Pin pin : pins) {
                 if (pin.notEmpty()) {
-                    ctx.write(makeStringMessage(ctx, HARDWARE, msgId, pin.makeHardwareBody()), ctx.voidPromise());
+                    ctx.write(makeStringMessage(HARDWARE, msgId, pin.makeHardwareBody()), ctx.voidPromise());
                 }
             }
         } else {
             if (pins[0].notEmpty()) {
-                ctx.write(makeStringMessage(ctx, HARDWARE, msgId, makeHardwareBody()), ctx.voidPromise());
+                ctx.write(makeStringMessage(HARDWARE, msgId, makeHardwareBody()), ctx.voidPromise());
             }
         }
     }

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/outputs/LabeledValueDisplay.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/outputs/LabeledValueDisplay.java
@@ -47,7 +47,7 @@ public class LabeledValueDisplay extends OnePinWidget implements FrequencyWidget
     public void send(ChannelHandlerContext ctx, int msgId) {
         final String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/model/widgets/outputs/ValueDisplay.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/widgets/outputs/ValueDisplay.java
@@ -42,7 +42,7 @@ public class ValueDisplay extends OnePinWidget implements FrequencyWidget, Hardw
     public void send(ChannelHandlerContext ctx, int msgId) {
         final String body = makeHardwareBody();
         if (body != null) {
-            ctx.write(makeStringMessage(ctx, HARDWARE, msgId, body), ctx.voidPromise());
+            ctx.write(makeStringMessage(HARDWARE, msgId, body), ctx.voidPromise());
         }
     }
 

--- a/server/core/src/main/java/cc/blynk/server/core/protocol/handlers/DefaultExceptionHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/core/protocol/handlers/DefaultExceptionHandler.java
@@ -28,7 +28,7 @@ public interface DefaultExceptionHandler {
             BaseServerException baseServerException = (BaseServerException) cause;
             //no need for stack trace for known exceptions
             log.error(baseServerException.getMessage());
-            ctx.writeAndFlush(makeResponse(ctx, baseServerException.msgId, baseServerException.errorCode), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(baseServerException.msgId, baseServerException.errorCode), ctx.voidPromise());
         } else {
             handleUnexpectedException(ctx, cause);
         }

--- a/server/core/src/main/java/cc/blynk/server/handlers/common/PingLogic.java
+++ b/server/core/src/main/java/cc/blynk/server/handlers/common/PingLogic.java
@@ -13,7 +13,7 @@ import static cc.blynk.utils.ByteBufUtil.*;
 public class PingLogic {
 
     public static void messageReceived(ChannelHandlerContext ctx, int messageId) {
-        ctx.writeAndFlush(ok(ctx, messageId), ctx.voidPromise());
+        ctx.writeAndFlush(ok(messageId), ctx.voidPromise());
     }
 
 }

--- a/server/core/src/main/java/cc/blynk/utils/ByteBufUtil.java
+++ b/server/core/src/main/java/cc/blynk/utils/ByteBufUtil.java
@@ -3,9 +3,7 @@ package cc.blynk.utils;
 import cc.blynk.server.core.protocol.enums.Command;
 import cc.blynk.server.core.protocol.model.messages.MessageBase;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.CharsetUtil;
 
 import static cc.blynk.server.core.protocol.enums.Response.*;
@@ -20,47 +18,23 @@ import static cc.blynk.server.core.protocol.enums.Response.*;
  */
 public class ByteBufUtil {
 
-    public static ByteBuf ok(ChannelHandlerContext ctx, int msgId) {
-        return makeResponse(ctx.alloc(), msgId, OK);
+    public static ByteBuf ok(int msgId) {
+        return makeResponse(msgId, OK);
     }
 
-    public static ByteBuf ok(Channel channel, int msgId) {
-        return makeResponse(channel.alloc(), msgId, OK);
-    }
-
-    public static ByteBuf makeResponse(ChannelHandlerContext ctx, int msgId, int response) {
-        return makeResponse(ctx.alloc(), msgId, response);
-    }
-
-    public static ByteBuf makeResponse(Channel channel, int msgId, int response) {
-        return makeResponse(channel.alloc(), msgId, response);
-    }
-
-    private static ByteBuf makeResponse(ByteBufAllocator allocator, int msgId, int response) {
-        return allocator.ioBuffer(MessageBase.HEADER_LENGTH)
+    public static ByteBuf makeResponse(int msgId, int response) {
+        return PooledByteBufAllocator.DEFAULT.buffer(MessageBase.HEADER_LENGTH)
                 .writeByte(Command.RESPONSE)
                 .writeShort(msgId)
                 .writeShort(response);
     }
 
-    public static ByteBuf makeStringMessage(ChannelHandlerContext ctx, short cmd, int msgId, String data) {
-        return makeBinaryMessage(ctx.alloc(), cmd, msgId, data.getBytes(CharsetUtil.UTF_8));
+    public static ByteBuf makeStringMessage(short cmd, int msgId, String data) {
+        return makeBinaryMessage(cmd, msgId, data.getBytes(CharsetUtil.UTF_8));
     }
 
-    public static ByteBuf makeStringMessage(Channel channel, short cmd, int msgId, String data) {
-        return makeBinaryMessage(channel.alloc(), cmd, msgId, data.getBytes(CharsetUtil.UTF_8));
-    }
-
-    public static ByteBuf makeBinaryMessage(ChannelHandlerContext ctx, short cmd, int msgId, byte[] byteData) {
-        return makeBinaryMessage(ctx.alloc(), cmd, msgId, byteData);
-    }
-
-    public static ByteBuf makeBinaryMessage(Channel channel, short cmd, int msgId, byte[] byteData) {
-        return makeBinaryMessage(channel.alloc(), cmd, msgId, byteData);
-    }
-
-    private static ByteBuf makeBinaryMessage(ByteBufAllocator allocator, short cmd, int msgId, byte[] byteData) {
-        return allocator.ioBuffer(MessageBase.HEADER_LENGTH + byteData.length)
+    public static ByteBuf makeBinaryMessage(short cmd, int msgId, byte[] byteData) {
+        return PooledByteBufAllocator.DEFAULT.buffer(MessageBase.HEADER_LENGTH + byteData.length)
                 .writeByte(cmd)
                 .writeShort(msgId)
                 .writeShort(byteData.length)

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/auth/AppLoginHandler.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/auth/AppLoginHandler.java
@@ -86,7 +86,7 @@ public class AppLoginHandler extends SimpleChannelInboundHandler<LoginMessage> i
 
     private void completeLogin(Channel channel, Session session, String userName, int msgId) {
         session.addAppChannel(channel);
-        channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+        channel.writeAndFlush(ok(msgId), channel.voidPromise());
         log.info("{} app joined.", userName);
     }
 

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/auth/RegisterHandler.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/auth/RegisterHandler.java
@@ -52,7 +52,7 @@ public class RegisterHandler extends SimpleChannelInboundHandler<RegisterMessage
         //expecting message with 2 parts, described above in comment.
         if (messageParts.length != 2) {
             log.error("Register Handler. Wrong income message format. {}", message);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, ILLEGAL_COMMAND), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, ILLEGAL_COMMAND), ctx.voidPromise());
             return;
         }
 
@@ -62,19 +62,19 @@ public class RegisterHandler extends SimpleChannelInboundHandler<RegisterMessage
 
         if (!EmailValidator.getInstance().isValid(userName)) {
             log.error("Register Handler. Wrong email: {}", userName);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, ILLEGAL_COMMAND), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, ILLEGAL_COMMAND), ctx.voidPromise());
             return;
         }
 
         if (userDao.isUserExists(userName)) {
             log.warn("User with name {} already exists.", userName);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, USER_ALREADY_REGISTERED), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, USER_ALREADY_REGISTERED), ctx.voidPromise());
             return;
         }
 
         if (allowedUsers != null && !allowedUsers.contains(userName)) {
             log.warn("User with name {} not allowed to register.", userName);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NOT_ALLOWED), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, NOT_ALLOWED), ctx.voidPromise());
             return;
         }
 
@@ -82,7 +82,7 @@ public class RegisterHandler extends SimpleChannelInboundHandler<RegisterMessage
 
         log.info("Registered {}.", userName);
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
     @Override

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/ActivateDashboardLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/ActivateDashboardLogic.java
@@ -47,22 +47,22 @@ public class ActivateDashboardLogic {
         Session session = sessionDao.userSession.get(user);
 
         if (session.hasHardwareOnline(dashId)) {
-            ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+            ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
         } else {
             log.debug("No device in session.");
-            ctx.writeAndFlush(makeResponse(ctx, message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
         }
 
         for (Channel appChannel : session.getAppChannels()) {
             if (appChannel != ctx.channel() && getAppState(appChannel) != null) {
-                appChannel.write(makeStringMessage(appChannel, message.command, message.id, message.body));
+                appChannel.write(makeStringMessage(message.command, message.id, message.body));
             }
 
             for (Widget widget : dash.widgets) {
                 String body = widget.makeHardwareBody();
                 if (body != null) {
                     final String data = dashId + StringUtils.BODY_SEPARATOR_STRING + body;
-                    appChannel.write(makeStringMessage(appChannel, SYNC, 1111, data));
+                    appChannel.write(makeStringMessage(SYNC, 1111, data));
                 }
             }
 

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AddEnergyLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AddEnergyLogic.java
@@ -43,7 +43,7 @@ public class AddEnergyLogic {
         }
 
         user.purchaseEnergy(energyAmountToAdd);
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
     private static boolean isValidTransactionId(String id) {

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AddPushLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AddPushLogic.java
@@ -43,6 +43,6 @@ public class AddPushLogic {
                 break;
         }
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AppMailLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/AppMailLogic.java
@@ -63,10 +63,10 @@ public class AppMailLogic {
         blockingIOProcessor.execute(() -> {
             try {
                 mailWrapper.send(to, subj, body);
-                channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+                channel.writeAndFlush(ok(msgId), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error sending email from application. For user {}.",  username, e);
-                channel.writeAndFlush(makeResponse(channel, msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
             }
         });
     }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/DeActivateDashboardLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/DeActivateDashboardLogic.java
@@ -50,7 +50,7 @@ public class DeActivateDashboardLogic {
             }
         }
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/GetEnergyLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/GetEnergyLogic.java
@@ -17,7 +17,7 @@ import static cc.blynk.utils.ByteBufUtil.*;
 public class GetEnergyLogic {
 
     public static void messageReceived(ChannelHandlerContext ctx, User user, StringMessage message) {
-        ctx.writeAndFlush(makeStringMessage(ctx, GET_ENERGY, message.id, String.valueOf(user.getEnergy())), ctx.voidPromise());
+        ctx.writeAndFlush(makeStringMessage(GET_ENERGY, message.id, String.valueOf(user.getEnergy())), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/GetTokenLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/GetTokenLogic.java
@@ -32,6 +32,6 @@ public class GetTokenLogic {
 
         String token = userDao.tokenManager.getToken(user, dashId);
 
-        ctx.writeAndFlush(makeStringMessage(ctx, GET_TOKEN, message.id, token), ctx.voidPromise());
+        ctx.writeAndFlush(makeStringMessage(GET_TOKEN, message.id, token), ctx.voidPromise());
     }
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/LoadProfileGzippedLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/LoadProfileGzippedLogic.java
@@ -37,10 +37,10 @@ public class LoadProfileGzippedLogic {
 
         try {
             byte[] data = ByteUtils.compress(body);
-            ctx.writeAndFlush(makeBinaryMessage(ctx, LOAD_PROFILE_GZIPPED, message.id, data), ctx.voidPromise());
+            ctx.writeAndFlush(makeBinaryMessage(LOAD_PROFILE_GZIPPED, message.id, data), ctx.voidPromise());
         } catch (IOException e) {
             log.error("Error compressing data.", e);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NO_DATA_EXCEPTION));
+            ctx.writeAndFlush(makeResponse(message.id, NO_DATA_EXCEPTION));
         }
     }
 

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/RefreshTokenLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/RefreshTokenLogic.java
@@ -32,6 +32,6 @@ public class RefreshTokenLogic {
 
         String token = userDao.tokenManager.refreshToken(user, dashId, user.dashTokens);
 
-        ctx.writeAndFlush(makeStringMessage(ctx, REFRESH_TOKEN, message.id, token), ctx.voidPromise());
+        ctx.writeAndFlush(makeStringMessage(REFRESH_TOKEN, message.id, token), ctx.voidPromise());
     }
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/CreateDashLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/CreateDashLogic.java
@@ -66,7 +66,7 @@ public class CreateDashLogic {
         user.profile.dashBoards = ArrayUtil.add(user.profile.dashBoards, newDash);
         user.lastModifiedTs = System.currentTimeMillis();
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/DeleteDashLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/DeleteDashLogic.java
@@ -49,7 +49,7 @@ public class DeleteDashLogic {
 
         user.lastModifiedTs = System.currentTimeMillis();
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/SaveDashLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/SaveDashLogic.java
@@ -66,7 +66,7 @@ public class SaveDashLogic {
         user.profile.dashBoards[index] = updatedDash;
         user.lastModifiedTs = System.currentTimeMillis();
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/CreateWidgetLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/CreateWidgetLogic.java
@@ -66,7 +66,7 @@ public class CreateWidgetLogic {
         dash.updatedAt = System.currentTimeMillis();
         user.lastModifiedTs = dash.updatedAt;
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/DeleteWidgetLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/DeleteWidgetLogic.java
@@ -50,7 +50,7 @@ public class DeleteWidgetLogic {
         existingWidgetIndex = dash.getWidgetIndex(widgetId, message.id);
         deleteWidget(user, dash, existingWidgetIndex);
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
     /**

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/UpdateWidgetLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/dashboard/widget/UpdateWidgetLogic.java
@@ -71,7 +71,7 @@ public class UpdateWidgetLogic {
         dash.updatedAt = System.currentTimeMillis();
         user.lastModifiedTs = dash.updatedAt;
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/reporting/GetGraphDataLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/reporting/GetGraphDataLogic.java
@@ -52,7 +52,7 @@ public class GetGraphDataLogic {
         //special case for delete command
         if (messageParts.length == 4) {
             deleteGraphData(messageParts, user.name, message.id);
-            ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+            ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
         } else {
             int dashId = ParseUtil.parseInt(messageParts[0], message.id);
             user.profile.validateDashId(dashId, message.id);
@@ -78,12 +78,12 @@ public class GetGraphDataLogic {
                 byte[][] data = reportingDao.getAllFromDisk(username, requestedPins, msgId);
                 byte[] compressed = compress(requestedPins[0].dashId, data);
 
-                channel.writeAndFlush(makeBinaryMessage(channel, GET_GRAPH_DATA_RESPONSE, msgId, compressed), channel.voidPromise());
+                channel.writeAndFlush(makeBinaryMessage(GET_GRAPH_DATA_RESPONSE, msgId, compressed), channel.voidPromise());
             } catch (NoDataException noDataException) {
-                channel.writeAndFlush(makeResponse(channel, msgId, NO_DATA_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NO_DATA_EXCEPTION), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error reading reporting data. For user {}", username);
-                channel.writeAndFlush(makeResponse(channel, msgId, SERVER_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, SERVER_EXCEPTION), channel.voidPromise());
             }
         });
     }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/GetShareTokenLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/GetShareTokenLogic.java
@@ -41,6 +41,6 @@ public class GetShareTokenLogic {
 
         user.subtractEnergy(PRIVATE_TOKEN_PRICE, message.id);
 
-        ctx.writeAndFlush(makeStringMessage(ctx, GET_SHARE_TOKEN, message.id, token), ctx.voidPromise());
+        ctx.writeAndFlush(makeStringMessage(GET_SHARE_TOKEN, message.id, token), ctx.voidPromise());
     }
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/RefreshShareTokenLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/RefreshShareTokenLogic.java
@@ -50,11 +50,11 @@ public class RefreshShareTokenLogic {
         for (Channel appChannel : session.getAppChannels()) {
             AppShareStateHolder state = getShareState(appChannel);
             if (state != null && state.dashId == dashId) {
-                ChannelFuture cf = appChannel.writeAndFlush(makeResponse(appChannel, message.id, NOT_ALLOWED));
+                ChannelFuture cf = appChannel.writeAndFlush(makeResponse(message.id, NOT_ALLOWED));
                 cf.addListener(channelFuture -> appChannel.close());
             }
         }
 
-        ctx.writeAndFlush(makeStringMessage(ctx, REFRESH_SHARE_TOKEN, message.id, token), ctx.voidPromise());
+        ctx.writeAndFlush(makeStringMessage(REFRESH_SHARE_TOKEN, message.id, token), ctx.voidPromise());
     }
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/ShareLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/main/logic/sharing/ShareLogic.java
@@ -52,7 +52,7 @@ public class ShareLogic {
             }
         }
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/sharing/auth/AppShareLoginHandler.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/sharing/auth/AppShareLoginHandler.java
@@ -68,7 +68,7 @@ public class AppShareLoginHandler extends SimpleChannelInboundHandler<ShareLogin
 
         if (user == null || !user.name.equals(userName)) {
             log.debug("Share token is invalid. User : {}, token {}, {}", userName, token, ctx.channel().remoteAddress());
-            ctx.writeAndFlush(makeResponse(ctx, messageId, NOT_ALLOWED), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(messageId, NOT_ALLOWED), ctx.voidPromise());
             return;
         }
 
@@ -77,7 +77,7 @@ public class AppShareLoginHandler extends SimpleChannelInboundHandler<ShareLogin
         DashBoard dash = user.profile.getDashById(dashId);
         if (!dash.isShared) {
             log.debug("Dashboard is not shared. User : {}, token {}, {}", userName, token, ctx.channel().remoteAddress());
-            ctx.writeAndFlush(makeResponse(ctx, messageId, NOT_ALLOWED), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(messageId, NOT_ALLOWED), ctx.voidPromise());
             return;
         }
 
@@ -96,7 +96,7 @@ public class AppShareLoginHandler extends SimpleChannelInboundHandler<ShareLogin
 
     private void completeLogin(Channel channel, Session session, String userName, int msgId) {
         session.addAppChannel(channel);
-        channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+        channel.writeAndFlush(ok(msgId), channel.voidPromise());
         log.info("Shared {} app joined.", userName);
     }
 

--- a/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/sharing/logic/HardwareAppShareLogic.java
+++ b/server/tcp-app-server/src/main/java/cc/blynk/server/application/handlers/sharing/logic/HardwareAppShareLogic.java
@@ -45,13 +45,13 @@ public class HardwareAppShareLogic {
 
         if (!dashBoard.isActive) {
             log.debug("No active dashboard.");
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
             return;
         }
 
         if (!dashBoard.isShared) {
             log.debug("Dashboard is not shared. User : {}, {}", state.user.name, ctx.channel().remoteAddress());
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NOT_ALLOWED), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, NOT_ALLOWED), ctx.voidPromise());
             return;
         }
 
@@ -66,7 +66,7 @@ public class HardwareAppShareLogic {
                 if (sharedToken != null) {
                     for (Channel appChannel : session.getAppChannels()) {
                         if (appChannel != ctx.channel() && Session.needSync(appChannel, sharedToken)) {
-                            appChannel.writeAndFlush(makeStringMessage(appChannel, SYNC, message.id, message.body), appChannel.voidPromise());
+                            appChannel.writeAndFlush(makeStringMessage(SYNC, message.id, message.body), appChannel.voidPromise());
                         }
                     }
                 }

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/auth/HardwareLoginHandler.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/auth/HardwareLoginHandler.java
@@ -68,7 +68,7 @@ public class HardwareLoginHandler extends SimpleChannelInboundHandler<LoginMessa
 
         if (user == null) {
             log.debug("HardwareLogic token is invalid. Token '{}', '{}'", token, ctx.channel().remoteAddress());
-            ctx.writeAndFlush(makeResponse(ctx, message.id, INVALID_TOKEN), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, INVALID_TOKEN), ctx.voidPromise());
             return;
         }
 
@@ -77,7 +77,7 @@ public class HardwareLoginHandler extends SimpleChannelInboundHandler<LoginMessa
         DashBoard dash = user.profile.getDashById(dashId);
         if (dash == null) {
             log.warn("User : {} requested token {} for non-existing {} dash id.", user.name, token, dashId);
-            ctx.writeAndFlush(makeResponse(ctx, message.id, INVALID_TOKEN), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, INVALID_TOKEN), ctx.voidPromise());
             return;
         }
 

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/BridgeLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/BridgeLogic.java
@@ -55,7 +55,7 @@ public class BridgeLogic {
 
             sendToMap.put(pin, token);
 
-            ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+            ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
         } else {
             final String pin = split[0];
             final String token = sendToMap.get(pin);
@@ -75,10 +75,10 @@ public class BridgeLogic {
                     }
                 }
                 if (!messageWasSent) {
-                    ctx.writeAndFlush(makeResponse(ctx, message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
+                    ctx.writeAndFlush(makeResponse(message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
                 }
             } else {
-                ctx.writeAndFlush(makeResponse(ctx, message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
+                ctx.writeAndFlush(makeResponse(message.id, DEVICE_NOT_IN_NETWORK), ctx.voidPromise());
             }
         }
     }

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareInfoLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareInfoLogic.java
@@ -46,7 +46,7 @@ public class HardwareInfoLogic {
             ctx.pipeline().addFirst(new ReadTimeoutHandler(newReadTimeout));
         }
 
-        ctx.writeAndFlush(ok(ctx, message.id), ctx.voidPromise());
+        ctx.writeAndFlush(ok(message.id), ctx.voidPromise());
     }
 
 }

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareLogic.java
@@ -83,7 +83,7 @@ public class HardwareLogic {
             session.sendToApps(HARDWARE, message.id, dashId + StringUtils.BODY_SEPARATOR_STRING + body);
         } else {
             log.debug("No active dashboard.");
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
         }
     }
 

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareSyncLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/HardwareSyncLogic.java
@@ -45,7 +45,7 @@ public class HardwareSyncLogic {
             String[] bodyParts = message.body.split(StringUtils.BODY_SEPARATOR_STRING);
 
             if (bodyParts.length < 2) {
-                ctx.writeAndFlush(makeResponse(ctx, message.id, Response.ILLEGAL_COMMAND), ctx.voidPromise());
+                ctx.writeAndFlush(makeResponse(message.id, Response.ILLEGAL_COMMAND), ctx.voidPromise());
                 return;
             }
 
@@ -57,7 +57,7 @@ public class HardwareSyncLogic {
                 if (widget instanceof RTC)  {
                     RTC rtc = (RTC) widget;
                     final String body = Pin.makeHardwareBody(pinType, pin, getTime(rtc));
-                    ctx.writeAndFlush(makeStringMessage(ctx, HARDWARE, message.id, body), ctx.voidPromise());
+                    ctx.writeAndFlush(makeStringMessage(HARDWARE, message.id, body), ctx.voidPromise());
                 } else if (widget instanceof HardwareSyncWidget) {
                     ((HardwareSyncWidget) widget).send(ctx, message.id);
                     ctx.flush();

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/MailLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/MailLogic.java
@@ -70,10 +70,10 @@ public class MailLogic extends NotificationBase {
         blockingIOProcessor.execute(() -> {
             try {
                 mailWrapper.send(to, subj, body);
-                channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+                channel.writeAndFlush(ok(msgId), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error sending mail from hardware. For user {}.",  username, e);
-                channel.writeAndFlush(makeResponse(channel, msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
             }
         });
     }

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/PushLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/PushLogic.java
@@ -52,7 +52,7 @@ public class PushLogic extends NotificationBase {
 
         if (!dash.isActive) {
             log.debug("No active dashboard.");
-            ctx.writeAndFlush(makeResponse(ctx, message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
+            ctx.writeAndFlush(makeResponse(message.id, NO_ACTIVE_DASHBOARD), ctx.voidPromise());
             return;
         }
 
@@ -86,10 +86,10 @@ public class PushLogic extends NotificationBase {
         blockingIOProcessor.execute(() -> {
             try {
                 gcmWrapper.send(message);
-                channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+                channel.writeAndFlush(ok(msgId), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error sending push notification from hardware. For user {}. {}",  username, e.getMessage());
-                channel.writeAndFlush(makeResponse(channel, msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
 
                 if (e.getMessage() != null && e.getMessage().contains("NotRegistered")) {
                     log.error("Removing invalid token. UID {}", uid);

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/SmsLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/SmsLogic.java
@@ -63,10 +63,10 @@ public class SmsLogic extends NotificationBase {
         blockingIOProcessor.execute(() -> {
             try {
                 smsWrapper.send(to, body);
-                channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+                channel.writeAndFlush(ok(msgId), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error sending sms for user {}. Reason : {}",  username, e.getMessage());
-                channel.writeAndFlush(makeResponse(channel, msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
             }
         });
     }

--- a/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/TwitLogic.java
+++ b/server/tcp-hardware-server/src/main/java/cc/blynk/server/hardware/handlers/hardware/logic/TwitLogic.java
@@ -62,10 +62,10 @@ public class TwitLogic extends NotificationBase {
         blockingIOProcessor.execute(() -> {
             try {
                 twitterWrapper.send(token, secret, body);
-                channel.writeAndFlush(ok(channel, msgId), channel.voidPromise());
+                channel.writeAndFlush(ok(msgId), channel.voidPromise());
             } catch (Exception e) {
                 log.error("Error sending twit for user {}. Reason : {}",  username, e.getMessage());
-                channel.writeAndFlush(makeResponse(channel, msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
+                channel.writeAndFlush(makeResponse(msgId, NOTIFICATION_EXCEPTION), channel.voidPromise());
             }
         });
     }


### PR DESCRIPTION
* ``ByteBufUtil``: no need to depend on ``Channel`` or ``ChannelHandlerContext``, use just ``PooledByteBufAllocator.DEFAULT`` for allocation; this caused most changes.

* ``Session``: familty of _sendMessageTo()_ methods seems like renders idea of sending one message to different channels; sort of 'multicast'; downside is that same msg is being constructed again and again while looping on channels; an idea of refactoring -- create only one message, send it in a loop by just reseting reader index when iterating.

