### PR TITLE
Session sendMessageTo* optimization ++ micro benchmark test

### DIFF
--- a/server/core/src/main/java/cc/blynk/server/core/model/auth/Session.java
+++ b/server/core/src/main/java/cc/blynk/server/core/model/auth/Session.java
@@ -13,19 +13,20 @@ import io.netty.util.internal.ConcurrentSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static cc.blynk.utils.ByteBufUtil.*;
-import static cc.blynk.utils.StateHolderUtil.*;
+import static cc.blynk.utils.ByteBufUtil.makeResponse;
+import static cc.blynk.utils.ByteBufUtil.makeStringMessage;
+import static cc.blynk.utils.StateHolderUtil.getHardState;
 
 /**
  * The Blynk Project.
  * Created by Dmitriy Dumanskiy.
  * Created on 2/1/2015.
- *
+ * <p>
  * DefaultChannelGroup.java too complicated. so doing in simple way for now.
- *
  */
 public class Session {
 
@@ -84,13 +85,13 @@ public class Session {
     }
 
     public boolean sendMessageToHardware(int activeDashId, short cmd, int msgId, String body) {
-        Set<Channel> targetChannels = hardwareChannels.stream().
-                filter(channel -> {
-                            HardwareStateHolder hardwareState = getHardState(channel);
-                            return hardwareState != null && hardwareState.dashId == activeDashId;
-                        }
-                ).
-                collect(Collectors.toSet());
+        Set<Channel> targetChannels = new HashSet<>();
+        for (Channel channel : hardwareChannels) {
+            HardwareStateHolder hardwareState = getHardState(channel);
+            if (hardwareState != null && hardwareState.dashId == activeDashId) {
+                targetChannels.add(channel);
+            }
+        }
 
         int channelsNum = targetChannels.size();
         if (channelsNum == 0)
@@ -151,9 +152,12 @@ public class Session {
     }
 
     public void sendToSharedApps(Channel sendingChannel, String sharedToken, short cmd, int msgId, String body) {
-        Set<Channel> targetChannels = appChannels.stream().
-                filter(appChannel -> appChannel != sendingChannel && needSync(appChannel, sharedToken)).
-                collect(Collectors.toSet());
+        Set<Channel> targetChannels = new HashSet<>();
+        for (Channel channel : appChannels) {
+            if (channel != sendingChannel && needSync(channel, sharedToken)) {
+                targetChannels.add(channel);
+            }
+        }
 
         int channelsNum = targetChannels.size();
         if (channelsNum == 0)

--- a/server/core/src/test/java/cc/blynk/server/core/model/auth/SessionPerfTest.java
+++ b/server/core/src/test/java/cc/blynk/server/core/model/auth/SessionPerfTest.java
@@ -1,0 +1,125 @@
+package cc.blynk.server.core.model.auth;
+
+import cc.blynk.server.core.protocol.model.messages.MessageBase;
+import cc.blynk.server.core.session.HardwareStateHolder;
+import cc.blynk.server.handlers.BaseSimpleChannelInboundHandler;
+import cc.blynk.utils.ServerProperties;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class SessionPerfTest {
+    static final int DASH_ID = 1;
+
+    Session session1;
+    Session session2;
+    Session session3;
+    Session session4;
+    int i1;
+    int i2;
+    int i3;
+    int i4;
+
+    @Setup
+    public void setup() {
+        // disable logging
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration conf = ctx.getConfiguration();
+        conf.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).setLevel(org.apache.logging.log4j.Level.OFF);
+        ctx.updateLoggers(conf);
+
+        // create handler with HardwareStateHolder
+        User user = new User("user");
+        user.putToken(DASH_ID, "1", user.dashTokens);
+
+        HardwareStateHolder hardwareStateHolder = new HardwareStateHolder(DASH_ID, user, "1");
+
+        // create 1 hardware channel and a session
+        session1 = new Session(null);
+        session1.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create two hardware channels and a session
+        session2 = new Session(null);
+        session2.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session2.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create 3 hardware channels and a session
+        session3 = new Session(null);
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create 4 hardware channels and a session
+        session4 = new Session(null);
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_1Channel() {
+        session1.sendMessageToHardware(DASH_ID, (short) i1, i1, "body:" + (i1++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_2Channels() {
+        session2.sendMessageToHardware(DASH_ID, (short) i2, i2, "body:" + (i2++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_3Channels() {
+        session3.sendMessageToHardware(DASH_ID, (short) i3, i3, "body:" + (i3++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_4Channels() {
+        session4.sendMessageToHardware(DASH_ID, (short) i4, i4, "body:" + (i4++));
+    }
+
+    @TearDown
+    public void teardown() {
+        session1.closeAll();
+        session2.closeAll();
+        session3.closeAll();
+        session4.closeAll();
+    }
+
+    private ChannelHandler newChannelHandler(final HardwareStateHolder hardwareStateHolder) {
+        return new BaseSimpleChannelInboundHandler(new ServerProperties(), hardwareStateHolder) {
+            @Override
+            protected void messageReceived(ChannelHandlerContext ctx, MessageBase msg) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private class EmbeddedChannel extends io.netty.channel.embedded.EmbeddedChannel {
+        public EmbeddedChannel(ChannelHandler... handlers) {
+            super(handlers);
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            return null;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## With lambdas
```bash
Result "sendMessageToHardware_1Channel":
  421.681 ±(99.9%) 10.155 ns/op \[Average\]
  (min, avg, max) = (412.314, 421.681, 454.206), stdev = 9.499
  CI (99.9%): \[411.526, 431.836\] (assumes normal distribution)

Result "sendMessageToHardware_2Channels":
  482.553 ±(99.9%) 9.576 ns/op \[Average\]
  (min, avg, max) = (460.661, 482.553, 497.359), stdev = 8.958
  CI (99.9%): \[472.976, 492.129\] (assumes normal distribution)

Benchmark                                        Mode  Cnt    Score    Error  Units
SessionPerfTest.sendMessageToHardware_1Channel   avgt   15  421.681 ± 10.155  ns/op
SessionPerfTest.sendMessageToHardware_2Channels  avgt   15  482.553 ±  9.576  ns/op

```
## With no lambdas (plain if-s)
```bash
Result "sendMessageToHardware_1Channel":
  344.877 ±(99.9%) 6.639 ns/op \[Average\]
  (min, avg, max) = (336.088, 344.877, 356.549), stdev = 6.210
  CI (99.9%): \[338.238, 351.516\] (assumes normal distribution)

Result "sendMessageToHardware_2Channels":
  410.046 ±(99.9%) 8.168 ns/op \[Average\]
  (min, avg, max) = (397.710, 410.046, 420.379), stdev = 7.641
  CI (99.9%): \[401.877, 418.214\] (assumes normal distribution)

Benchmark                                        Mode  Cnt    Score   Error  Units
SessionPerfTest.sendMessageToHardware_1Channel   avgt   15  344.877 ± 6.639  ns/op
SessionPerfTest.sendMessageToHardware_2Channels  avgt   15  410.046 ± 8.168  ns/op
```
