### PR TITLE
Benchmark test for session.sendMessageToHardware

### DIFF
--- a/server/core/src/test/java/cc/blynk/server/core/model/auth/SessionPerfTest.java
+++ b/server/core/src/test/java/cc/blynk/server/core/model/auth/SessionPerfTest.java
@@ -1,0 +1,125 @@
+package cc.blynk.server.core.model.auth;
+
+import cc.blynk.server.core.protocol.model.messages.MessageBase;
+import cc.blynk.server.core.session.HardwareStateHolder;
+import cc.blynk.server.handlers.BaseSimpleChannelInboundHandler;
+import cc.blynk.utils.ServerProperties;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class SessionPerfTest {
+    static final int DASH_ID = 1;
+
+    Session session1;
+    Session session2;
+    Session session3;
+    Session session4;
+    int i1;
+    int i2;
+    int i3;
+    int i4;
+
+    @Setup
+    public void setup() {
+        // disable logging
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration conf = ctx.getConfiguration();
+        conf.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).setLevel(org.apache.logging.log4j.Level.OFF);
+        ctx.updateLoggers(conf);
+
+        // create handler with HardwareStateHolder
+        User user = new User("user");
+        user.putToken(DASH_ID, "1", user.dashTokens);
+
+        HardwareStateHolder hardwareStateHolder = new HardwareStateHolder(DASH_ID, user, "1");
+
+        // create 1 hardware channel and a session
+        session1 = new Session(null);
+        session1.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create two hardware channels and a session
+        session2 = new Session(null);
+        session2.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session2.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create 3 hardware channels and a session
+        session3 = new Session(null);
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session3.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+
+        // create 4 hardware channels and a session
+        session4 = new Session(null);
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+        session4.getHardwareChannels().add(new EmbeddedChannel(newChannelHandler(hardwareStateHolder)));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_1Channel() {
+        session1.sendMessageToHardware(DASH_ID, (short) i1, i1, "body:" + (i1++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_2Channels() {
+        session2.sendMessageToHardware(DASH_ID, (short) i2, i2, "body:" + (i2++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_3Channels() {
+        session3.sendMessageToHardware(DASH_ID, (short) i3, i3, "body:" + (i3++));
+    }
+
+    @Benchmark
+    public void sendMessageToHardware_4Channels() {
+        session4.sendMessageToHardware(DASH_ID, (short) i4, i4, "body:" + (i4++));
+    }
+
+    @TearDown
+    public void teardown() {
+        session1.closeAll();
+        session2.closeAll();
+        session3.closeAll();
+        session4.closeAll();
+    }
+
+    private ChannelHandler newChannelHandler(final HardwareStateHolder hardwareStateHolder) {
+        return new BaseSimpleChannelInboundHandler(new ServerProperties(), hardwareStateHolder) {
+            @Override
+            protected void messageReceived(ChannelHandlerContext ctx, MessageBase msg) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private class EmbeddedChannel extends io.netty.channel.embedded.EmbeddedChannel {
+        public EmbeddedChannel(ChannelHandler... handlers) {
+            super(handlers);
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            return null;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Session as-is, no optimization (baseline test)
```bash
Result "sendMessageToHardware_1Channel":
  285.155 ±(99.9%) 18.809 ns/op \[Average\]
  (min, avg, max) = (269.328, 285.155, 311.523), stdev = 17.594
  CI (99.9%): \[266.346, 303.963\] (assumes normal distribution)

Result "sendMessageToHardware_2Channels":
  497.653 ±(99.9%) 9.981 ns/op \[Average\]
  (min, avg, max) = (484.544, 497.653, 516.760), stdev = 9.336
  CI (99.9%): [487.672, 507.634] (assumes normal distribution)

Benchmark                                        Mode  Cnt    Score    Error  Units
SessionPerfTest.sendMessageToHardware_1Channel   avgt   15  285.155 ± 18.809  ns/op
SessionPerfTest.sendMessageToHardware_2Channels  avgt   15  497.653 ±  9.981  ns/op

```

BTW, for 3,4 channels (not commited) results show:
```bash
SessionPerfTest.sendMessageToHardware_3Channels  avgt   15  715.128 ± 10.118  ns/op
SessionPerfTest.sendMessageToHardware_4Channels  avgt   15  891.657 ± 9.842  ns/op
```