### PR TITLE
Mem leak fix in http

### DIFF
--- a/server/core/src/main/java/cc/blynk/server/core/BaseHttpHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/core/BaseHttpHandler.java
@@ -13,6 +13,7 @@ import cc.blynk.server.handlers.http.rest.URIDecoder;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -55,6 +56,7 @@ public class BaseHttpHandler extends ChannelInboundHandlerAdapter implements Def
 
         if (handlerHolder == null) {
             log.error("Error resolving url. No path found. {} : {}", req.getMethod().name(), req.getUri());
+            ReferenceCountUtil.release(req);
             ctx.writeAndFlush(Response.notFound());
             return;
         }
@@ -73,6 +75,8 @@ public class BaseHttpHandler extends ChannelInboundHandlerAdapter implements Def
         } catch (Exception e) {
             ctx.writeAndFlush(Response.serverError(e.getMessage()));
             return;
+        } finally {
+            ReferenceCountUtil.release(req);
         }
 
         finishHttp(ctx, uriDecoder, handlerHolder, params);

--- a/server/core/src/main/java/cc/blynk/server/handlers/http/logic/StaticFileHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/handlers/http/logic/StaticFileHandler.java
@@ -17,7 +17,7 @@ import java.util.*;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http.HttpVersion.*;
 
 /**
  * The Blynk Project.

--- a/server/core/src/main/java/cc/blynk/server/handlers/http/logic/StaticFileHandler.java
+++ b/server/core/src/main/java/cc/blynk/server/handlers/http/logic/StaticFileHandler.java
@@ -23,7 +23,7 @@ import static io.netty.handler.codec.http.HttpVersion.*;
  * Created by Dmitriy Dumanskiy.
  * Created on 10.12.15.
  */
-public class StaticFileHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+public class StaticFileHandler extends ChannelInboundHandlerAdapter {
 
     public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
     public static final String HTTP_DATE_GMT_TIMEZONE = "GMT";


### PR DESCRIPTION
Run integration-tests with ``-Dio.netty.leakDetection.level=paranoid``, look for error logs: ``LEAK: {}.release() was not called before it's garbage-collected`` (see class ``io.netty.util.ResourceLeakDetector``).
This happens because in ``BaseHttpHandler`` a buffer isn't being released in following servers: ``HttpResetPassServer``, ``HttpAPIServer``; **BUT** buffer will be released if ``BaseHttpHandler`` goes in those servers: ``HttpsAdminServer``, ``HttpsAPIServer``-- because of preceding ``StaticFileHandler`` which releases buffer because it extends ``SimpleChannelInboundHandler``. So problem with http leak -- sometimes http_req buffer being released, sometimes isn't.

**Changes:**
Make ``StaticFileHandler`` extend good-old ``ChannelInboundHandlerAdapter`` and make it release  buffer when needed. 
In ``BaseHttpHandler`` always release a buffer after ``handlerHolder.fetchParams()`` call.