### PR TITLE
Add net.interface property support

### DIFF
--- a/server/core/src/main/java/cc/blynk/server/Holder.java
+++ b/server/core/src/main/java/cc/blynk/server/Holder.java
@@ -74,7 +74,8 @@ public class Holder implements Closeable {
         this.props = serverProperties;
 
         this.region = serverProperties.getProperty("region", "local");
-        this.currentIp = serverProperties.getProperty("reset-pass.http.host", IPUtils.resolveHostIP());
+        String netInterface = serverProperties.getProperty("net.interface", "eth");
+        this.currentIp = serverProperties.getProperty("reset-pass.http.host", IPUtils.resolveHostIP(netInterface));
 
         this.redisClient = new RedisClient(new ServerProperties(RedisClient.REDIS_PROPERTIES), region);
 
@@ -117,7 +118,8 @@ public class Holder implements Closeable {
         this.props = serverProperties;
 
         this.region = "local";
-        this.currentIp = serverProperties.getProperty("reset-pass.http.host", IPUtils.resolveHostIP());
+        String netInterface = serverProperties.getProperty("net.interface", "eth");
+        this.currentIp = serverProperties.getProperty("reset-pass.http.host", IPUtils.resolveHostIP(netInterface));
         this.redisClient = new RedisClient(new ServerProperties(RedisClient.REDIS_PROPERTIES), "real");
 
         String dataFolder = serverProperties.getProperty("data.folder");

--- a/server/core/src/main/java/cc/blynk/utils/IPUtils.java
+++ b/server/core/src/main/java/cc/blynk/utils/IPUtils.java
@@ -19,12 +19,12 @@ public class IPUtils {
 
     private static final Logger log = LogManager.getLogger(IPUtils.class);
 
-    public static String resolveHostIP() {
+    public static String resolveHostIP(String netInterface) {
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
                 NetworkInterface networkInterface = interfaces.nextElement();
-                if (networkInterface.getDisplayName().startsWith("eth")) {
+                if (networkInterface.getDisplayName().startsWith(netInterface)) {
                     Enumeration<InetAddress> ips = networkInterface.getInetAddresses();
                     while (ips.hasMoreElements()) {
                         InetAddress inetAddress = ips.nextElement();

--- a/server/core/src/main/resources/server.properties
+++ b/server/core/src/main/resources/server.properties
@@ -134,6 +134,11 @@ administration.https.port=7443
 #it is recommended to override this property with your server IP to avoid possible problems of host resolving
 #reset-pass.http.host=
 
+#network interface to determine server's current IP.
+#only the first characters of the interface's name are needed.
+#the default setting eth will use the first ethX interface found (i.e. eth0)
+net.interface=eth
+
 #comma separated list of administrator IPs. allow access to admin UI only for those IPs.
 #you may set it for 0.0.0.0/0 to allow access for all.
 #you may use CIDR notation. For instance, 192.168.0.53/24

--- a/server/http-api/src/main/java/cc/blynk/server/api/http/logic/ResetPasswordLogic.java
+++ b/server/http-api/src/main/java/cc/blynk/server/api/http/logic/ResetPasswordLogic.java
@@ -52,7 +52,8 @@ public class ResetPasswordLogic {
         this.emailBody = FileLoaderUtil.readFileAsString(RESET_PASS_STATIC_PATH + "reset-email.html");
         this.mailWrapper = mailWrapper;
 
-        String host = props.getProperty("reset-pass.http.host", IPUtils.resolveHostIP());
+        String netInterface = props.getProperty("net.interface", "eth");
+        String host = props.getProperty("reset-pass.http.host", IPUtils.resolveHostIP(netInterface));
         this.resetPassUrl = "http://" + host + "/landing?token=";
         this.pageContent = FileLoaderUtil.readFileAsString(RESET_PASS_STATIC_PATH + "enterNewPassword.html");
     }


### PR DESCRIPTION
Adds the ability to set a name for the network interface to be used in determining server's current IP.
This is done through a new net.interface property in server.properties