### PR TITLE
use docker argument for running in background

### DIFF
--- a/server/Docker/README.md
+++ b/server/Docker/README.md
@@ -14,7 +14,7 @@ docker build -t blynk .
 ### RUN
 
 ```bash
-docker run --name blynk-server -v ~/blynk-server/server/Docker:/data -p 8440:8440 -p 8080:8080 -p 9443:9443 blynk &
+docker run --name blynk-server -v ~/blynk-server/server/Docker:/data -p 8440:8440 -p 8080:8080 -p 9443:9443 -d blynk 
 ```
 
 Don't forget to change the port attribution if you change on the ENV vars in Dockerfile


### PR DESCRIPTION
To get the container running in the background, we can use the -d argument of the docker client instead of ending the command with &